### PR TITLE
fixed core only mode issue

### DIFF
--- a/msyd/main.py
+++ b/msyd/main.py
@@ -306,7 +306,7 @@ def call(args):
                                          base=args.incremental)
     logger.info("Read input files")
 
-    syndict = intersection.process_syndicts(syndict, cores=args.cores)
+    syndict = intersection.process_syndicts(syndict, cores=args.cores, only_core=args.core)
     logger.info("Intersected synteny")
 
     if args.realign:


### PR DESCRIPTION
Fixes issue #19  with call so that the --core option is respected. Also fixed a bug in the local add_filtered function (that wasn't being run due to only_core always being false) that double counted the reference, resulting in skipping of all core syn regions when only_core == True.