### PR TITLE
implement parallel vcf merging

### DIFF
--- a/msyd/main.py
+++ b/msyd/main.py
@@ -197,6 +197,9 @@ def main():
     merge_parser.add_argument("-o", dest='outfile',
                               required=True, type=argparse.FileType('wt'),
                               help="Where to store the merged VCF.")
+    merge_parser.add_argument("-c", dest="cores",
+                              type=int, default=1,
+                              help="Number of cores to use for parallel computation.")
 
     realign_parser = subparsers.add_parser("realign",
                                            help="Iteratively realign a set of genomes based on a PSF file",
@@ -306,7 +309,7 @@ def call(args):
                                          base=args.incremental)
     logger.info("Read input files")
 
-    syndict = intersection.process_syndicts(syndict, cores=args.cores)
+    syndict = intersection.process_syndicts(syndict, cores=args.cores, only_core=args.core)
     logger.info("Intersected synteny")
 
     if args.realign:
@@ -363,7 +366,7 @@ def call(args):
 
         tmpfile = util.gettmpfile()
         logger.info(f"Merging VCFs, saving to {tmpfile}")
-        vcf.reduce_vcfs(vcfs, tmpfile)
+        vcf.reduce_vcfs(vcfs, tmpfile, cores=args.cores)
 
         if args.impute:
             logger.info(f"Imputing reference genotypes in syntenic regions, saving to {args.vcf.name}")
@@ -386,7 +389,7 @@ def merge(args):
 
     # temporary function to better test the vcf merging functionality
     logger.info(f"Merging {args.vcfs} to {args.outfile.name}")
-    vcf.reduce_vcfs(args.vcfs, args.outfile.name)
+    vcf.reduce_vcfs(args.vcfs, args.outfile.name, cores=args.cores)
     logger.info(f"Finished running msyd merge, output saved to {args.outfile.name}.")
 
 # call the plotsr ordering functionality on a set of organisms described in the .tsv

--- a/msyd/main.py
+++ b/msyd/main.py
@@ -309,7 +309,7 @@ def call(args):
                                          base=args.incremental)
     logger.info("Read input files")
 
-    syndict = intersection.process_syndicts(syndict, cores=args.cores, only_core=args.core)
+    syndict = intersection.process_syndicts(syndict, cores=args.cores)
     logger.info("Intersected synteny")
 
     if args.realign:

--- a/msyd/pyxfiles/vcf.pyx
+++ b/msyd/pyxfiles/vcf.pyx
@@ -316,7 +316,7 @@ cdef add_syn_ann(syn, ovcf, ref=None, no=None, add_cigar=False, add_identity=Tru
     ovcf.write(rec)
 
 
-cdef str merge_vcfs(lf: Union[str, os.PathLike], rf:Union[str, os.PathLike], of=None):
+cpdef str merge_vcfs(lf: Union[str, os.PathLike], rf:Union[str, os.PathLike], of=None):
     if of is None:
         of = util.gettmpfile()
     logger.info(f"Merging {lf} and {rf} into {of}")


### PR DESCRIPTION
Hey Leon, hope you don't mind, I was finding that the vcf merging was quite slow for some of my bigger datasets (22 genomes) so since I was looking at the code anyway I thought I'd add a parallel reduce function to merge the vcfs faster. There was actually already a binary tree reduce function in util which I updated & then used in the reduce_vcfs function. It seems to be working for me although it unexpectedly reverses the order of the samples in the VCF.

I also noticed that as far as I can tell, msyd doesn't actually seem to clean up any of the tmp vcf files it creates. I didn't fix that but its maybe something to think about implementing ;)